### PR TITLE
Stadler: use configmap for destinations

### DIFF
--- a/infrastructure/collector-k8s-integration/k8s-integration.yaml
+++ b/infrastructure/collector-k8s-integration/k8s-integration.yaml
@@ -30,29 +30,17 @@ spec:
         kind: HelmRepository
         name: k8s-monitoring
       interval: 5m
+
+  # https://fluxcd.io/flux/components/helm/helmreleases/#values-references
+  # note that we can use both valuesFrom, and values:
+  valuesFrom:
+    - kind: ConfigMap
+      name: k8s-int-otlp-destinations
+      valuesKey: destinations-list
+
   values:
     cluster:
       name: stadler-k8s-int
-
-    destinations:
-      - name: otlp-gateway
-        type: otlp
-        url: https://YOUR_OTLP_GATEWAY.grafana.net/otlp
-        protocol: http
-
-        auth:
-          type: basic
-          usernameKey: username
-          passwordKey: password
-        secret:
-          create: false
-          name: grafanacloud-otlphttp-secret
-          namespace: collector
-
-        metrics: {enabled: true}
-        logs: {enabled: true}
-        traces: {enabled: true}
-
     alloy-receiver:
       enabled: true
       controller:
@@ -67,7 +55,6 @@ spec:
             port: 4317
             targetPort: 4317
             protocol: TCP
-
     applicationObservability:
       enabled: true
       receivers:
@@ -76,15 +63,11 @@ spec:
             enabled: true
           http:
             enabled: true
-
     clusterEvents:
       enabled: true
-
     clusterMetrics:
       enabled: true
-
     alloy-metrics:
       enabled: true
-
     alloy-singleton:
       enabled: true

--- a/pre-provision/k8s-integration.sh
+++ b/pre-provision/k8s-integration.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
+ #!/bin/bash
 
 : '
 This script requires that you have the following values exported:
-export K8S_INT_OTLP_USERNAME_BASE64=
-export K8S_INT_OTLP_PASSSWORD_BASE64=
+export ALLOY_CLOUD_OTLP_URL=
+export ALLOY_OTLP_USERNAME_BASE64=
+export ALLOY_OTLP_PASSSWORD_BASE64=
 '
 
 echo "
@@ -12,7 +13,30 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: collector
-
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-int-otlp-destinations
+  namespace: collector
+data:
+  destinations-list: |-
+    destinations:
+    - name: otlp-gateway
+      type: otlp
+      url: $ALLOY_CLOUD_OTLP_URL
+      protocol: http
+      auth:
+        type: basic
+        usernameKey: username
+        passwordKey: password
+      secret:
+        create: false
+        name: grafanacloud-otlphttp-secret
+        namespace: collector
+      metrics: {enabled: true}
+      logs: {enabled: true}
+      traces: {enabled: true}
 ---
 apiVersion: v1
 kind: Secret
@@ -21,6 +45,6 @@ metadata:
   namespace: collector
 type: Opaque
 data:
-  username: $K8S_INT_OTLP_USERNAME_BASE64
-  password: $K8S_INT_OTLP_PASSSWORD_BASE64
+  username: $ALLOY_CLOUD_OTLP_USERNAME_BASE64
+  password: $ALLOY_CLOUD_OTLP_PASSSWORD_BASE64
 " | kubectl apply -f -


### PR DESCRIPTION
## what this does

In keeping with the "2 hats" model, we want to continue to let the Platform Engineer be in charge of placing values from the SaaS platform (Grafana Cloud) into the cluster, and then the Dev team come along and deploy Alloy, knowing that those values are already there.

As far as I have seen, there is not an existing way in the K8s integration v2 Helm chart, to specify the URLs for destinations as coming from configMaps. 

Therefore I have pulled the entire destinations list into a configMap, so that the Platform Engineer can generate it with an exported value (the OTLP endpoint URL) which they got from Grafana Cloud.

It would be great to learn if there's a better way to do this.
