### PR TITLE
correct the FE proxy LB section, and leave enabled in the prod env

### DIFF
--- a/apps/production/oteldemo-values.yaml
+++ b/apps/production/oteldemo-values.yaml
@@ -30,9 +30,8 @@ spec:
     opensearch:
       enabled: false
 
-    # components:
-
-    #   # set up LB ingress for the proxy (i.e. for k6 testing)
-    #   frontendProxy:
-    #     service:
-    #       type: LoadBalancer
+    # uncommment 4 lines below to expose the frontend proxy with an external IP address (tested only on GKE)
+    components:
+      frontendProxy:
+        service:
+          type: LoadBalancer


### PR DESCRIPTION
## what this is

For the hands-on workshop, I want frontend-proxy to be set up as a loadbalancer with an external IP, by default. This will save a step that the audience will have already seen/done in the staging environment, in an earlier hands-on section.

## todo 

When I get to creating a new documentation section about using the production settings, I'll make a big note about the fact that this LB is turned on by default.